### PR TITLE
fix other place in documentation where ~ is not expanded

### DIFF
--- a/source/includes/_orderbook_blockchain.md
+++ b/source/includes/_orderbook_blockchain.md
@@ -17,7 +17,7 @@ import {DriftClient, UserMap, Wallet, loadKeypair} from "@drift-labs/sdk";
 const connection = new Connection("https://api.mainnet-beta.solana.com");
 
 const keyPairFile = `${process.env.HOME}/.config/solana/my-keypair.json`;
-const wallet = new Wallet(loadKeypair(privateKeyFile))
+const wallet = new Wallet(loadKeypair(keyPairFile))
 
 const driftClient = new DriftClient({
   connection,
@@ -65,7 +65,7 @@ import {DriftClient, OrderSubscriber, Wallet, loadKeypair} from "@drift-labs/sdk
 const connection = new Connection("https://api.mainnet-beta.solana.com");
 
 const keyPairFile = `${process.env.HOME}/.config/solana/my-keypair.json`;
-const wallet = new Wallet(loadKeypair(privateKeyFile))
+const wallet = new Wallet(loadKeypair(keyPairFile))
 
 const driftClient = new DriftClient({
   connection,

--- a/source/includes/_orderbook_blockchain.md
+++ b/source/includes/_orderbook_blockchain.md
@@ -16,7 +16,7 @@ import {DriftClient, UserMap, Wallet, loadKeypair} from "@drift-labs/sdk";
 
 const connection = new Connection("https://api.mainnet-beta.solana.com");
 
-const keyPairFile = '~/.config/solana/my-keypair.json';
+const keyPairFile = `${process.env.HOME}/.config/solana/my-keypair.json`;
 const wallet = new Wallet(loadKeypair(privateKeyFile))
 
 const driftClient = new DriftClient({
@@ -64,7 +64,7 @@ import {DriftClient, OrderSubscriber, Wallet, loadKeypair} from "@drift-labs/sdk
 
 const connection = new Connection("https://api.mainnet-beta.solana.com");
 
-const keyPairFile = '~/.config/solana/my-keypair.json';
+const keyPairFile = `${process.env.HOME}/.config/solana/my-keypair.json`;
 const wallet = new Wallet(loadKeypair(privateKeyFile))
 
 const driftClient = new DriftClient({

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -142,7 +142,7 @@ import {Wallet, loadKeypair, DriftClient} from "@drift-labs/sdk";
 
 const connection = new Connection('https://api.mainnet-beta.solana.com');
 
-const keyPairFile = '~/.config/solana/my-keypair.json';
+const keyPairFile = `${process.env.HOME}/.config/solana/my-keypair.json`;
 const wallet = new Wallet(loadKeypair(keyPairFile))
 
 const driftClient = new DriftClient({


### PR DESCRIPTION
I just realized there are other code snippets where ~/config is used. This PR updates them so code snippet will not throw Error.
Also fixes the wrong variable used in the loadKeyPair initialization