### PR TITLE
Additions to v2-teacher + Swift market order example(TS)

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -104,6 +104,13 @@ Install driftpy from PyPI using pip:
 
 auto-generated documentation here: [https://drift-labs.github.io/driftpy/]
 
+<aside class="notice">
+  Recommended dependencies:
+  driftpy: 0.8.33, 
+  solana: 0.35.1, 
+  anchorpy: 0.20.1
+</aside>
+
 ## HTTP
 Use the self-hosted HTTP API [gateway](https://github.com/drift-labs/gateway)
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -88,12 +88,10 @@ Install @drift-labs/sdk from [npm](https://www.npmjs.com/package/@drift-labs/sdk
 
 `yarn add @drift-labs/sdk`
 
-auto-generated documentation here: (https://drift-labs.github.io/protocol-v2/sdk/)
+Auto-generated documentation <a href="https://drift-labs.github.io/protocol-v2/sdk/">here</a>
 
 <aside class="notice">
-  Recommended dependencies:
-  drift-labs/sdk: 2.111.0-beta.6, 
-  solana/web3.js: 1.92.3
+  Latest TS dependencies can be found on GitHub <a href="https://github.com/drift-labs/protocol-v2/blob/master/sdk/package.json">here</a>
 </aside>
 
 
@@ -102,13 +100,11 @@ Install driftpy from PyPI using pip:
 
 `pip install driftpy`
 
-auto-generated documentation here: [https://drift-labs.github.io/driftpy/]
+Auto-generated documentation <a href="https://drift-labs.github.io/driftpy/">here</a>
 
 <aside class="notice">
-  Recommended dependencies:
-  driftpy: 0.8.33, 
-  solana: 0.35.1, 
-  anchorpy: 0.20.1
+  Latest Python dependencies can be found on GitHub <a href="https://github.com/drift-labs/driftpy/blob/master/pyproject.toml">here</a>
+
 </aside>
 
 ## HTTP

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -234,6 +234,15 @@ await driftClient.subscribe();
 | market_lookup_table   | Public key for the market lookup table                                                          | Yes      | None                            |
 
 
+
+  When subscribing to the client for delegate accounts, you have to be explicit about the following parameters:
+```
+subAccountIds: [SUBACCOUNT_ID],
+activeSubAccountId: SUBACCOUNT_ID,
+authority: TARGET_AUTHORITY,
+```
+
+
 ## User Initialization
 
 <aside class="notice">

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1297,6 +1297,26 @@ const marketOrderParams = {
 ```
 
 ## Order example(limit taker)
+For a limit taker order, make sure your order price is above the oracle price.
+The current parameters will result in an order 1% above oracle price.
+
+```typescript
+const MarketIndex = 0; // 0 = SOL-PERP market
+const direction = PositionDirection.LONG;
+
+const oracleInfo = driftClient.getOracleDataForPerpMarket(MarketIndex);
+
+const limitOrderParams = {
+    orderType: OrderType.LIMIT,
+    marketIndex: perpMarketIndex,
+    marketType: MarketType.PERP,
+    direction,
+    baseAssetAmount: driftClient.convertToPerpPrecision(1), // Size 1 Sol
+    price: oracleInfo.price.muln(101).divn(100), // 1% higher than oracle price
+};
+```
+
+## Order example(limit maker)
 ```typescript
 const MarketIndex = 0; // 0 = SOL-PERP market
 const direction = PositionDirection.LONG;
@@ -1308,12 +1328,8 @@ const limitOrderParams = {
     direction,
     baseAssetAmount: driftClient.convertToPerpPrecision(1), // Size 1 Sol
     price: driftClient.convertToPricePrecision(100), // At price 100
+    postOnly: true // Ensures maker only
 };
-```
-
-## Order example(limit maker)
-```typescript
-WIP
 ```
 
 ## Sign order

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -94,7 +94,6 @@ auto-generated documentation here: (https://drift-labs.github.io/protocol-v2/sdk
   Recommended dependencies:
   drift-labs/sdk: 2.111.0-beta.6, 
   solana/web3.js: 1.92.3
-    
 </aside>
 
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -88,7 +88,15 @@ Install @drift-labs/sdk from [npm](https://www.npmjs.com/package/@drift-labs/sdk
 
 `yarn add @drift-labs/sdk`
 
-auto-generated documentation here: [https://drift-labs.github.io/protocol-v2/sdk/]
+auto-generated documentation here: (https://drift-labs.github.io/protocol-v2/sdk/)
+
+<aside class="notice">
+  Recommended dependencies:
+  drift-labs/sdk: 2.111.0-beta.6, 
+  solana/web3.js: 1.92.3
+    
+</aside>
+
 
 ## Python
 Install driftpy from PyPI using pip:
@@ -1313,7 +1321,7 @@ If token amount is greater than 0, it is a deposit. If less than zero, it is a b
 ```typescript
 const marketIndex = 0;
 
-const baseAssetAmount = user.getPerpPositions(
+const baseAssetAmount = user.getPerpPosition(
   marketIndex,
 )?.baseAssetAmount;
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1280,58 +1280,21 @@ To pass an order to Swift, the following steps are required:
 
 ## Order example(market taker)
 ```typescript
-const marketIndex = 0;
-const direction = PositionDirection.LONG
+const marketIndex = 0; // 0 = SOL-PERP market
 
 const oracleInfo = driftClient.getOracleDataForPerpMarket(marketIndex);
 const highPrice = oracleInfo.price.muln(101).divn(100);
 const lowPrice = oracleInfo.price;
 
-const makerOrderParams = getMarketOrderParams({
+const orderParams = getMarketOrderParams({
     marketIndex: marketIndex,
     marketType: MarketType.PERP,
-    direction: direction,
+    direction: PositionDirection.LONG,
     baseAssetAmount: driftClient.convertToPerpPrecision(0.1), // 0.1 SOL,
     auctionStartPrice: isVariant(direction, 'long') ? lowPrice : highPrice,
 		auctionEndPrice: isVariant(direction, 'long') ? highPrice : lowPrice,
 		auctionDuration: 50,
 });
-```
-
-## Order example(limit taker) WIP
-For a limit taker order, make sure your order price is above the oracle price.
-The current parameters will result in an order 1% above oracle price.
-
-```typescript
-const MarketIndex = 0; // 0 = SOL-PERP market
-const direction = PositionDirection.LONG;
-
-const oracleInfo = driftClient.getOracleDataForPerpMarket(MarketIndex);
-
-const limitOrderParams = {
-    orderType: OrderType.LIMIT,
-    marketIndex: perpMarketIndex,
-    marketType: MarketType.PERP,
-    direction,
-    baseAssetAmount: driftClient.convertToPerpPrecision(1), // Size 1 Sol
-    price: oracleInfo.price.muln(101).divn(100), // 1% higher than oracle price
-};
-```
-
-## Order example(limit maker) WIP
-```typescript
-const MarketIndex = 0; // 0 = SOL-PERP market
-const direction = PositionDirection.LONG;
-
-const limitOrderParams = {
-    orderType: OrderType.LIMIT,
-    marketIndex: perpMarketIndex,
-    marketType: MarketType.PERP,
-    direction,
-    baseAssetAmount: driftClient.convertToPerpPrecision(1), // Size 1 Sol
-    price: driftClient.convertToPricePrecision(100), // At price 100
-    postOnly: true // Ensures maker only
-};
 ```
 
 ## Sign order

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -138,7 +138,7 @@ from driftpy.keypair import load_keypair
 
 keypair_file = os.path.expanduser('~/.config/solana/my-keypair.json')
 keypair = load_keypair(keypair_file)
-wallet = Wallet(kp)
+wallet = Wallet(keypair)
 ```
 ```shell
 # use `DRIFT_GATEWAY_KEY` environment variable to configure the gateway wallet
@@ -1313,7 +1313,7 @@ If token amount is greater than 0, it is a deposit. If less than zero, it is a b
 ```typescript
 const marketIndex = 0;
 
-const baseAssetAmount = user.getPerpPosition(
+const baseAssetAmount = user.getPerpPositions(
   marketIndex,
 )?.baseAssetAmount;
 


### PR DESCRIPTION
-Adds section on Swift orders, with the following code examples:
1. Example market order
2. Generate and Sign order
3. Submit to Swift API

-Adds section on client init for delegate accounts
-Adds embedded links to most recent dependencies for TS an Python
-Updates formatting of existing links to autogen docs, for consistency
-Update typo